### PR TITLE
added glossary.coffee

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "hubot-trollbot": "^0.1.1",
     "hubot-youtube": "^0.1.2",
     "jsdom": "^1.5.0",
+    "js-yaml": "3.4.1",
     "moment": "^2.8.4",
     "twit": "^1.1.18",
     "underscore": "^1.7.0",

--- a/scripts/glossary.coffee
+++ b/scripts/glossary.coffee
@@ -14,14 +14,14 @@ yaml = require('js-yaml');
 
 module.exports = (robot) ->
 
-  robot.respond /glossary (\w+)/i, (msg) ->
+  robot.respond /(glossary|define) (\w+)/i, (msg) ->
     robot.http("https://api.github.com/repos/18f/procurement-glossary/contents/abbreviations.yml")
       .header('User-Agent', '18F-bot')
       .get() (err, res, body) -> 
         b = new Buffer(JSON.parse(body).content, 'base64');
         g = yaml.safeLoad(b.toString()).abbreviations 
-        
-        term = msg.match[1]
+
+        term = msg.match[2]
 
         if term in Object.keys(g)
           console.log "The term " + g[term].longform + " (" +  term + ") means " + g[term].description

--- a/scripts/glossary.coffee
+++ b/scripts/glossary.coffee
@@ -1,0 +1,26 @@
+# Description:
+#   Ask for an explanation of an abbreviation/jargon
+#
+# Depdeendencies:
+#   "js-yaml": "3.4.1"
+#
+# Commands:
+#   hubot glossary <abbreviation> - returns a defined term
+#
+# Examples:
+#   hubot glossary ATO
+
+yaml = require('js-yaml');
+
+module.exports = (robot) ->
+
+  robot.respond /glossary (\w+)/i, (msg) ->
+    robot.http("https://raw.githubusercontent.com/18F/procurement-glossary/master/abbreviations.yml")
+      .get() (err, res, body) -> 
+        g = yaml.safeLoad(body).abbreviations 
+        term = msg.match[1]
+
+        if term in Object.keys(g)
+          console.log "The term " + g[term].longform + " (" +  term + ") means " + g[term].description
+        else
+          console.log "I don't know that term."

--- a/scripts/glossary.coffee
+++ b/scripts/glossary.coffee
@@ -15,9 +15,12 @@ yaml = require('js-yaml');
 module.exports = (robot) ->
 
   robot.respond /glossary (\w+)/i, (msg) ->
-    robot.http("https://raw.githubusercontent.com/18F/procurement-glossary/master/abbreviations.yml")
+    robot.http("https://api.github.com/repos/18f/procurement-glossary/contents/abbreviations.yml")
+      .header('User-Agent', '18F-bot')
       .get() (err, res, body) -> 
-        g = yaml.safeLoad(body).abbreviations 
+        b = new Buffer(JSON.parse(body).content, 'base64');
+        g = yaml.safeLoad(b.toString()).abbreviations 
+        
         term = msg.match[1]
 
         if term in Object.keys(g)


### PR DESCRIPTION
Added a glossary listener to get an explanation of an abbreviation/jargon.

Usage: `hubot glossary <abbreviation>` would return a defined term

Example: 

`hubot glossary ATO` returns:

> The term Authority to Operate (ATO) means: A sign-off from an authorized agency official for a website to be allowed to engage with citizens, including security and some other stuff. Historically this is a 3-6 month process, but 18F has been working to fix this.