### PR TITLE
fix glossary script

### DIFF
--- a/scripts/glossary.coffee
+++ b/scripts/glossary.coffee
@@ -12,18 +12,26 @@
 
 yaml = require('js-yaml');
 
+findCaseInsensitively = (list, searchTerm) ->
+  searchTerm = searchTerm.toLowerCase()
+  for term in list
+    if term.toLowerCase() is searchTerm
+      return term
+  null # else return null
+
 module.exports = (robot) ->
-
   robot.respond /(glossary|define) (\w+)/i, (msg) ->
-    robot.http("https://api.github.com/repos/18f/procurement-glossary/contents/abbreviations.yml")
+    robot.http('https://api.github.com/repos/18f/procurement-glossary/contents/abbreviations.yml')
       .header('User-Agent', '18F-bot')
-      .get() (err, res, body) -> 
+      .get() (err, res, body) ->
         b = new Buffer(JSON.parse(body).content, 'base64');
-        g = yaml.safeLoad(b.toString()).abbreviations 
+        g = yaml.safeLoad(b.toString()).abbreviations
 
-        term = msg.match[2]
+        searchTerm = msg.match[2]
+        terms = Object.keys(g)
+        term = findCaseInsensitively(terms, searchTerm)
 
-        if term in Object.keys(g)
-          msg.reply "The term #{ g[term].longform } (#{ term }) means #{g[term].description}" 
+        if term
+          msg.reply "The term #{ g[term].longform } (#{ term }) means #{g[term].description}"
         else
           msg.reply "I don't know that term."

--- a/scripts/glossary.coffee
+++ b/scripts/glossary.coffee
@@ -24,6 +24,6 @@ module.exports = (robot) ->
         term = msg.match[2]
 
         if term in Object.keys(g)
-          console.log "The term " + g[term].longform + " (" +  term + ") means " + g[term].description
+          msg.reply "The term #{ g[term].longform } (#{ term }) means #{g[term].description}" 
         else
-          console.log "I don't know that term."
+          msg.reply "I don't know that term."


### PR DESCRIPTION
See 34d72b4 – it was working locally because `console.log()` shows up, but the response wasn't actually making it back to Slack. Also made it match terms case-insensitively.