### PR TITLE
Set Node engine to 4.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "underscore": "^1.7.0"
   },
   "engines": {
-    "node": "4.2.3"
+    "node": "4.2.2"
   }
 }


### PR DESCRIPTION
Looks like #42 isn't live yet after all:

```
OUT -----> Installing binaries
OUT        engines.node (package.json):  4.2.3
OUT        engines.npm (package.json):   unspecified (use default)
OUT        Downloading and installing node 4.2.3...
ERR DEPENDENCY MISSING IN MANIFEST: node 4.2.3
ERR It looks like you're trying to use node 4.2.3.
ERR Unfortunately, that version of node is not supported by this buildpack.
ERR The versions of node supported in this buildpack are:
ERR - 4.2.2
...
```

cc: @afeld @ccostino 