### PR TITLE
update opm message to include date

### DIFF
--- a/scripts/opm_status.coffee
+++ b/scripts/opm_status.coffee
@@ -24,5 +24,5 @@ module.exports = (robot) ->
         msg.send "Well, what does Capital Weather Gang say?"
       else
         status = JSON.parse(body)
-        msg.send status['Icon'] + ' ' + icons[status['Icon']] + ' - ' + status['StatusSummary'] + ' Read More: ' + status['Url']
+        msg.send "#{icons[status['Icon']]} #{status['Icon']} for #{status['AppliesTo']}. #{status['StatusSummary']}. Read More: \n #{status['Url']}"
       return


### PR DESCRIPTION
I realized that it was much more useful to add the "AppliesTo" date field to the message, because without that field it is confusing to see what date the message references.