### PR TITLE
Bump hubot-slack-github-issues to ^1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "hubot-scripts": "^2.5.16",
     "hubot-shipit": "^0.1.1",
     "hubot-slack": "18f/hubot-slack#3.4.2-handle-reaction-added",
-    "hubot-slack-github-issues": "^0.1.0",
+    "hubot-slack-github-issues": "^1.0.1",
     "hubot-standup": "git://github.com/miyagawa/hubot-standup.git#bf7dc4aeebb",
     "hubot-trollbot": "^0.1.1",
     "hubot-youtube": "^0.1.2",


### PR DESCRIPTION
Contains improvements from 18F/unit-testing-node as applied in 18F/hubot-slack-github-issues#43 (and the entry point fix from 18F/hubot-slack-github-issues#45).

Confirmed with both `npm run validate-config` and `bin/hubot` (the latter command finding the entry point problem fixed in 18F/hubot-slack-github-issues#45).

cc: @afeld