### PR TITLE
Catch all procurement terms for the glossary/define

### DIFF
--- a/scripts/glossary.coffee
+++ b/scripts/glossary.coffee
@@ -20,7 +20,7 @@ findCaseInsensitively = (list, searchTerm) ->
   null # else return null
 
 module.exports = (robot) ->
-  robot.respond /(glossary|define) (\w+)/i, (msg) ->
+  robot.respond /(glossary|define) (.+)/i, (msg) ->
     robot.http('https://api.github.com/repos/18f/procurement-glossary/contents/abbreviations.yml')
       .header('User-Agent', '18F-bot')
       .get() (err, res, body) ->

--- a/scripts/glossary.coffee
+++ b/scripts/glossary.coffee
@@ -27,7 +27,7 @@ module.exports = (robot) ->
         b = new Buffer(JSON.parse(body).content, 'base64');
         g = yaml.safeLoad(b.toString()).abbreviations
 
-        searchTerm = msg.match[2]
+        searchTerm = msg.match[2].trim()
         terms = Object.keys(g)
         term = findCaseInsensitively(terms, searchTerm)
 


### PR DESCRIPTION
Procurement terms can be multiple words and can include non-word characters (e.g., ampersands, parentheses, etc.).  This PR modifies the regex to capture them all.

Closes 18F/procurement-glossary#8