### PR TITLE
Less-strict YAML parsing

### DIFF
--- a/scripts/glossary.coffee
+++ b/scripts/glossary.coffee
@@ -25,7 +25,7 @@ module.exports = (robot) ->
       .header('User-Agent', '18F-bot')
       .get() (err, res, body) ->
         b = new Buffer(JSON.parse(body).content, 'base64');
-        g = yaml.safeLoad(b.toString()).abbreviations
+        g = yaml.safeLoad(b.toString(), { json: true }).abbreviations
 
         searchTerm = msg.match[2].trim()
         terms = Object.keys(g)


### PR DESCRIPTION
The upgrade to js-yaml 3.5.5 brought along a slightly stricter parser that throws an error on duplicate keys. Rather than have Charlie just not respond if the glossary yaml is imperfect, tell js-yaml to ignore duplicate key errors.

This is done by just adding { json: true } as an option to the yaml.safeLoad method call.