### PR TITLE
Cloud Foundry Diego compatibility

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 export PORT=$PORT
-export BIND_ADDRESS=$HOST
+export BIND_ADDRESS=0.0.0.0
 export PATH=./node_modules/.bin:$PATH
 ./node_modules/.bin/hubot --adapter slack --name charlie

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export PORT=$VCAP_APP_PORT
-export BIND_ADDRESS=$VCAP_APP_HOST
+export PORT=$PORT
+export BIND_ADDRESS=$HOST
 export PATH=./node_modules/.bin:$PATH
 ./node_modules/.bin/hubot --adapter slack --name charlie


### PR DESCRIPTION
Per [Cloud Foundry documentation] use of `$VCAP_APP_HOST` and `$VCAP_APP_PASSWORD` are incompatible with newer (Diego-based) Cloud Foundry deployments. This change makes this repository forward compatible with the new cloud.gov environment deployment in AWS GovCloud.
