### PR TITLE
Bookmark in #cloud-gov-support -> cg-docs

### DIFF
--- a/config/slack-github-issues.json
+++ b/config/slack-github-issues.json
@@ -19,6 +19,13 @@
       ]
     },
     {
+      "reactionName": "bookmark",
+      "githubRepository": "cg-docs",
+      "channelNames": [
+        "cloud-gov-support"
+      ]
+    },
+    {
       "reactionName": "evergreen_tree",
       "githubRepository": "handbook"
     },


### PR DESCRIPTION
I'd like to set up this hook so that we can easily tag pithy answers in #cloud-gov-support for addition to cloud.gov documentation.