### PR TITLE
Follow renamed repository

### DIFF
--- a/config/slack-github-issues.json
+++ b/config/slack-github-issues.json
@@ -6,7 +6,7 @@
   "rules": [
     {
       "reactionName": "bookmark",
-      "githubRepository": "cg-docs",
+      "githubRepository": "cg-site",
       "channelNames": [
         "cloud-gov-support"
       ]


### PR DESCRIPTION
The repository this points do moved, and as a result we got
```
Error: failed to create a GitHub issue in 18F/cg-docs: received 307 response from GitHub API: {"message":"Moved Permanently","url":"https://api.github.com/repositories/29991068/issues","documentation_url":"https://developer.github.com/v3/#http-redirects"}
```
