### PR TITLE
Save and report tock lines

### DIFF
--- a/scripts/tock_line.coffee
+++ b/scripts/tock_line.coffee
@@ -15,7 +15,7 @@ module.exports = (robot) ->
   robot.respond /tock line$/i, (msg) ->
     tock_lines = get_tock_lines(robot)
     if tock_lines[msg.envelope.room]
-      msg.send 'The tock line for #' + msg.envelope.room + ' is ' + tock_lines[msg.envelope.room]
+      msg.send 'The tock line for #' + msg.envelope.room + ' is `' + tock_lines[msg.envelope.room] + '`'
     else
       msg.send 'I don\'t know a tock line for this room!'
 

--- a/scripts/tock_line.coffee
+++ b/scripts/tock_line.coffee
@@ -1,0 +1,27 @@
+# Description:
+#   Inspect the data in redis easily
+#
+# Commands:
+#   hubot show users - Display all users that hubot knows about
+#   hubot show storage - Display the contents that are persisted in the brain
+
+get_tock_lines = (robot) ->
+    tock_lines = robot.brain.get('tock_lines')
+    if !tock_lines
+      tock_lines = { }
+    return tock_lines
+
+module.exports = (robot) ->
+  robot.respond /tock line$/i, (msg) ->
+    tock_lines = get_tock_lines(robot)
+    if tock_lines[msg.envelope.room]
+      msg.send 'The tock line for #' + msg.envelope.room + ' is ' + tock_lines[msg.envelope.room]
+    else
+      msg.send 'I don\'t know a tock line for this room!'
+
+  robot.respond /set tock line (.*)$/i, (msg) ->
+    tock_lines = get_tock_lines(robot)
+    tock_lines[msg.envelope.room] = msg.match[1]
+    robot.brain.set 'tock_lines', tock_lines
+    robot.brain.save()
+    msg.send 'Okay, I set the tock line for this room'

--- a/scripts/tock_line.coffee
+++ b/scripts/tock_line.coffee
@@ -12,16 +12,16 @@ get_tock_lines = (robot) ->
     return tock_lines
 
 module.exports = (robot) ->
-  robot.respond /tock line$/i, (msg) ->
+  robot.respond /tock( line)?$/i, (msg) ->
     tock_lines = get_tock_lines(robot)
     if tock_lines[msg.envelope.room]
       msg.send 'The tock line for #' + msg.envelope.room + ' is `' + tock_lines[msg.envelope.room] + '`'
     else
-      msg.send 'I don\'t know a tock line for this room!'
+      msg.send 'I don\'t know a tock line for this room. To set one, say `@' + robot.name + ' set tock line <line>`'
 
-  robot.respond /set tock line (.*)$/i, (msg) ->
+  robot.respond /set tock( line)? (.*)$/i, (msg) ->
     tock_lines = get_tock_lines(robot)
-    tock_lines[msg.envelope.room] = msg.match[1]
+    tock_lines[msg.envelope.room] = msg.match[2]
     robot.brain.set 'tock_lines', tock_lines
     robot.brain.save()
     msg.send 'Okay, I set the tock line for this room'


### PR DESCRIPTION
If Charlie is in a channel, he can be told to assign that channel a tock line.  Users can then ask him later what the tock line is.

Set a tock line:
```
@charlie set tock line 100 / DevOps / Bots / Charlie
```
> Okay, I set the tock line for this room

Retrieve a tock line:
```
@charlie tock line
```
> The tock line for #channel is `100 / DevOps / Bots / Charlie`