### PR TITLE
Fix XPOST

### DIFF
--- a/scripts/xpost.coffee
+++ b/scripts/xpost.coffee
@@ -16,9 +16,9 @@
 
 module.exports = (robot) ->
   console.log("XPOST script loaded.")
-  robot.hear /\bx\-?post #([\w\-]+)/i, (msg) ->
+  robot.hear /\bx\-?post #?([\w\-]+)/i, (msg) ->
     target = msg.match[1]
     poster = msg.message.user.name
-    text = msg.message.text
+    text = msg.message.text.replace(msg.match[0], '').trim()
     robot.messageRoom(target, "XPOST from " + poster + " in " + msg.message.room + " -- " + text)
     msg.send "cross-posted to #{target} (assuming I am in that channel); Thanks, #{poster}!"


### PR DESCRIPTION
Apparently the `#` doesn't come across with channel names anymore, so modify the regex to make it optional (in case it comes back someday).  Also cleaned up the cross-posted text to remove the `XPOST #channel` part of the message that gets posted to the other channel.