### PR TITLE
Get redis URL from VCAP_SERVICES

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "hubot-trollbot": "^0.1.1",
     "hubot-xkcd": "0.0.3",
     "hubot-youtube": "^1.0.2",
+    "json": "^9.0.4",
     "js-yaml": "^3.7.0",
     "twit": "^2.2.5",
     "underscore": "^1.8.3"

--- a/start.sh
+++ b/start.sh
@@ -3,7 +3,9 @@
 redishost=$(echo $VCAP_SERVICES | ./node_modules/.bin/json "redis28[0].credentials.hostname")
 redisport=$(echo $VCAP_SERVICES | ./node_modules/.bin/json "redis28[0].credentials.port")
 redispass=$(echo $VCAP_SERVICES | ./node_modules/.bin/json "redis28[0].credentials.password")
-export REDIS_URL="redis://dummy:$redispass@$redishost:$redisport"
+
+# Redis doesn't use usernames, so it can be anything.
+export REDIS_URL="redis://anyvalue:$redispass@$redishost:$redisport"
 
 export PORT=$PORT
 export BIND_ADDRESS=0.0.0.0

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 
+redishost=$(echo $VCAP_SERVICES | ./node_modules/.bin/json "redis28[0].credentials.hostname")
+redisport=$(echo $VCAP_SERVICES | ./node_modules/.bin/json "redis28[0].credentials.port")
+redispass=$(echo $VCAP_SERVICES | ./node_modules/.bin/json "redis28[0].credentials.password")
+export REDIS_URL="redis://dummy:$redispass@$redishost:$redisport"
+
 export PORT=$PORT
 export BIND_ADDRESS=0.0.0.0
 export PATH=./node_modules/.bin:$PATH
+
 ./node_modules/.bin/hubot --adapter slack --name charlie


### PR DESCRIPTION
Instead of requiring that the redis URL be set with `cf set-env`, read it from the `VCAP_SERVICES` env at startup and set it that way.  Just makes it a little easier.