### PR TITLE
Remove google images and translate, both of which are apparently broken

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -3,8 +3,6 @@
   "hubot-auth",
   "hubot-diagnostics",
   "hubot-help",
-  "hubot-google-images",
-  "hubot-google-translate",
   "hubot-pugme",
   "hubot-maps",
   "hubot-redis-brain",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,6 @@
     "hubot-ascii-art": "^1.1.1",
     "hubot-auth": "^2.0.0",
     "hubot-diagnostics": "0.0.1",
-    "hubot-google-images": "^0.2.6",
-    "hubot-google-translate": "^0.2.0",
     "hubot-help": "^0.2.0",
     "hubot-maps": "0.0.2",
     "hubot-pugme": "^0.1.0",


### PR DESCRIPTION
These scripts no longer appear to work, so might as well get rid of them.