### PR TITLE
For now, use our fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "hubot-trollbot": "^0.1.1",
     "hubot-xkcd": "0.0.3",
     "hubot-youtube": "^1.0.2",
-    "json": "^9.0.4",
     "js-yaml": "^3.7.0",
+    "json": "^9.0.4",
+    "slack-github-issues": "github:18f/slack-github-issues",
     "twit": "^2.2.5",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
The `slack-github-issues` script doesn't work correctly with private channels or DMs.  There are open PRs to fix it ([private channels](https://github.com/mbland/slack-github-issues/pull/4) and [direct messages](https://github.com/mbland/slack-github-issues/pull/3), but until that gets merged, let's use our fork.

The problem appears when users add an emoji reaction to a message in a private channel.  Charlie responds in-channel with an error about an undefined property:

![screen_shot_2017-01-25_at_1 03 22_pm_360](https://cloud.githubusercontent.com/assets/1775733/22304847/d203584e-e2fe-11e6-96f4-63070028590f.png)
