### PR TITLE
Enable github issues for standup-bot channel

### DIFF
--- a/config/slack-github-issues.json
+++ b/config/slack-github-issues.json
@@ -44,6 +44,13 @@
     {
       "reactionName": "koala",
       "githubRepository": "product-guide"
+    },
+    {
+      "reactionName": "standup-bot",
+      "githubRepository": "standup-slack-bot",
+      "channelNames": [
+        "standup-bot-dev"
+      ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.7.1",
   "private": true,
   "scripts": {
-    "validate-config": "hubot-slack-github-issues validate config/slack-github-issues.json"
+    "validate-config": "slack-github-issues validate config/slack-github-issues.json"
   },
   "dependencies": {
     "aws-sdk": "^2.7.21",


### PR DESCRIPTION
Use the :standup-bot: emoji reaction to create an issue in the https://github.com/18F/standup-slack-bot repo.