### PR TITLE
Switch back to @mbland's slack-github lib since it's fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "hubot-youtube": "^1.0.2",
     "js-yaml": "^3.7.0",
     "json": "^9.0.4",
-    "slack-github-issues": "github:18f/slack-github-issues",
     "twit": "^2.2.5",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
Now that [mbland/slack-github-issues](https://github.com/mbland/slack-github-issues) is fixed for private channels and DM, let's switch back to it!