### PR TITLE
Ship-it script has too many broken images

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -8,7 +8,6 @@
   "hubot-redis-brain",
   "hubot-rules",
   "hubot-scripts-us-federal-holidays",
-  "hubot-shipit",
   "hubot-slack-github-issues",
   "hubot-slack-reading-list",
   "hubot-trollbot",


### PR DESCRIPTION
And Hubot doesn't understand thread comments, so its responses to thread comments go to the main channel, which increases confusion related to image responses in general.