### PR TITLE
remove trollbot script

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -10,7 +10,6 @@
   "hubot-scripts-us-federal-holidays",
   "hubot-slack-github-issues",
   "hubot-slack-reading-list",
-  "hubot-trollbot",
   "hubot-xkcd",
   "hubot-youtube"
 ]

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "hubot-slack": "^4.3.1",
     "hubot-slack-github-issues": "^1.1.0",
     "hubot-slack-reading-list": "^1.0.1",
-    "hubot-trollbot": "^0.1.1",
     "hubot-xkcd": "0.0.3",
     "hubot-youtube": "^1.0.2",
     "js-yaml": "^3.7.0",


### PR DESCRIPTION
The trollbot script is confusing some people, who don't know why a bot is criticizing them, and annoying other people, who would prefer to do their work without a snarky bot making judgment. It might work in an environment where everybody is a developer, but that is not the case.