### PR TITLE
Remove Design-Wiki Github issue config

### DIFF
--- a/config/slack-github-issues.json
+++ b/config/slack-github-issues.json
@@ -34,10 +34,6 @@
       ]
     },
     {
-      "reactionName": "dart",
-      "githubRepository": "Design-Wiki"
-    },
-    {
       "reactionName": "evergreen_tree",
       "githubRepository": "handbook"
     },


### PR DESCRIPTION
The [Design Wiki repo](https://github.com/18F/Design-Wiki) is private and Charlie can't get to it (an issue related to 2FA).  Until we resolve that, let's remove this config so Charlie doesn't shout about `404` errors any time someone adds a `:dart:` emoji reaction.