### PR TITLE
[WIP] Add design wiki Github issue config

### DIFF
--- a/config/slack-github-issues.json
+++ b/config/slack-github-issues.json
@@ -34,6 +34,10 @@
       ]
     },
     {
+      "reactionName": "dart",
+      "githubRepository": "Design-Wiki"
+    },
+    {
       "reactionName": "evergreen_tree",
       "githubRepository": "handbook"
     },


### PR DESCRIPTION
# ❗️ ❗️ ❗️ Don't merge this

If/when we resolve how to get Charlie access to private repos or the design wiki becomes public, we can merge this to reenable that Github issue config.  For context, #108 removed this config.  When added back, it will create issues on the [Design-Wiki](https://github.com/18F/Design-Wiki) repo when a Slack message is tagged with the `:dart:` emoji.

@vishaliyer-18f: Just for your information.  :)