### PR TITLE
Use less intrusive customized zen script

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -5,7 +5,6 @@
 	"availability.coffee",
 	"aww.coffee",
 	"excuse.coffee",
-	"zen.coffee",
 	"room-info.coffee",
 	"python_library.coffee",
 	"twitter_stream.coffee",

--- a/scripts/zen.coffee
+++ b/scripts/zen.coffee
@@ -1,0 +1,22 @@
+# Description:
+#   Display GitHub zen message from https://api.github.com/zen API
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   None
+#
+# Commands:
+#   zen - Display GitHub zen message
+#
+# Author:
+#   anildigital
+#
+
+module.exports = (robot) ->
+  robot.respond /\bzen\b/i, (msg) ->
+    msg
+      .http("https://api.github.com/zen")
+      .get() (err, res, body) ->
+        msg.send body


### PR DESCRIPTION
Instead of using the [hubot-scripts zen script](https://github.com/github/hubot-scripts/blob/master/src/scripts/zen.coffee) that responds to _every_ mention of the word `zen`, use a custom script that only responds when the bot is directly addressed.  E.g., `@charlie zen`.