### PR TITLE
Emoji XPOST confirmation

### DIFF
--- a/scripts/xpost.coffee
+++ b/scripts/xpost.coffee
@@ -37,6 +37,17 @@ isInChannel = (robot, channel) ->
     return
 )
 
+addReaction = (robot, reaction, channelID, messageID) ->
+  new Promise((resolve, reject) ->
+    robot.adapter.client.web.reactions.add reaction, { channel: channelID, timestamp: messageID }, (err, res) ->
+      if err
+        return reject(err)
+      else if !res.ok
+        return reject(new Error('Unknown error with Slack API'))
+      resolve()
+      return
+)
+
 module.exports = (robot) ->
   console.log("XPOST script loaded.")
   robot.hear /\bx\-?post #([\w\-]+)/i, (msg) ->
@@ -59,7 +70,7 @@ module.exports = (robot) ->
             text: text
           } ]
           channel: target
-        msg.send "cross-posted to <##{result.channelID}>; Thanks <@#{poster}>!"
+        return addReaction(robot, 'hubot', msg.message.room, msg.message.id)
       else
         msg.send "I can't cross-post to <##{result.channelID}> because I'm not in there!"
       return


### PR DESCRIPTION
When Charlie successfully XPOSTs, add an emoji reaction to the original message instead of responding with a new message of its own.

![screen shot 2017-09-06 at 3 14 47 pm](https://user-images.githubusercontent.com/1775733/30132497-23a37eaa-9316-11e7-98f8-13b38a904dcd.png)

Closes #35 