### PR TITLE
Have Charlie use attached redis 3.2 service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,4 +20,4 @@
   links:
     - database:database
 database:
-  image: redis:latest
+  image: redis:3.2

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 if [ -z ${REDIS_URL} ]; then
-  redishost=$(echo $VCAP_SERVICES | ./node_modules/.bin/json "redis28[0].credentials.hostname")
-  redisport=$(echo $VCAP_SERVICES | ./node_modules/.bin/json "redis28[0].credentials.port")
-  redispass=$(echo $VCAP_SERVICES | ./node_modules/.bin/json "redis28[0].credentials.password")
+  redishost=$(echo $VCAP_SERVICES | ./node_modules/.bin/json "redis32[0].credentials.hostname")
+  redisport=$(echo $VCAP_SERVICES | ./node_modules/.bin/json "redis32[0].credentials.port")
+  redispass=$(echo $VCAP_SERVICES | ./node_modules/.bin/json "redis32[0].credentials.password")
 
   # Redis doesn't use usernames, so it can be anything.
   export REDIS_URL=${REDIS_URL:="redis://anyvalue:$redispass@$redishost:$redisport"}


### PR DESCRIPTION
Redis 2.x is being deprecated by cloud.gov.  This PR updates Charlie's environment handling to use connection info for a 3.2 service that is now attached to the charlie app.  Data from the 2.8 database has been migrated over.

Closes #118 