### PR TITLE
Have the bot announce when it boots up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@
     - HUBOT_SLACK_GITHUB_ISSUES_CONFIG_PATH=config/slack-github-issues.json
     - HUBOT_LOG_LEVEL=debug
     - REDIS_URL=redis://database:6379
+    - HUBOT_STATUS_CHANNEL=${HUBOT_STATUS_CHANNEL}
   working_dir: /app
   volumes:
     - ./:/app

--- a/scripts/startup_announce.js
+++ b/scripts/startup_announce.js
@@ -4,10 +4,8 @@
 const target = process.env.HUBOT_STATUS_CHANNEL || 'bots';
 
 module.exports = (robot) => {
-  setTimeout(() => {
-    robot.messageRoom(target, {
-      target,
-      text: 'Johnny 5 is alliiiiiive!  Also I have just booted up.'
-    })
-  }, 2000);
+  robot.messageRoom(target, {
+    target,
+    text: 'Johnny 5 is alliiiiiive!  Also I have just booted up.'
+  })
 };

--- a/scripts/startup_announce.js
+++ b/scripts/startup_announce.js
@@ -1,0 +1,13 @@
+// Description:
+//   Announce when the bot starts up
+
+const target = process.env.HUBOT_STATUS_CHANNEL || 'bots';
+
+module.exports = (robot) => {
+  setTimeout(() => {
+    robot.messageRoom(target, {
+      target,
+      text: 'Johnny 5 is alliiiiiive!  Also I have just booted up.'
+    })
+  }, 2000);
+};

--- a/test/scripts/startup_announce.js
+++ b/test/scripts/startup_announce.js
@@ -1,0 +1,38 @@
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('startup announcement', () => {
+  const robot = {
+    messageRoom: sinon.stub()
+  };
+
+  beforeEach(() => {
+    robot.messageRoom.reset();
+    delete require.cache[require.resolve('../../scripts/startup_announce')];
+  });
+
+  it('announces itself within 2 seconds of starting up, using default channel', () => {
+    const announceSetup = require('../../scripts/startup_announce');
+    announceSetup(robot);
+
+    return new Promise(resolve => {
+      setTimeout(() => {
+        expect(robot.messageRoom.calledWith('bots', { target: 'bots', text: sinon.match.string })).to.be.true;
+        resolve();
+      }, 2100);
+    });
+  }).timeout(2500);
+
+  it('uses the channel value from the environment, if provided', () => {
+    process.env.HUBOT_STATUS_CHANNEL = 'status-channel'
+    const announceSetup = require('../../scripts/startup_announce');
+    announceSetup(robot);
+
+    return new Promise(resolve => {
+      setTimeout(() => {
+        expect(robot.messageRoom.calledWith('status-channel', { target: 'status-channel', text: sinon.match.string })).to.be.true;
+        resolve();
+      }, 2100);
+    });
+  }).timeout(2500);
+});

--- a/test/scripts/startup_announce.js
+++ b/test/scripts/startup_announce.js
@@ -11,28 +11,18 @@ describe('startup announcement', () => {
     delete require.cache[require.resolve('../../scripts/startup_announce')];
   });
 
-  it('announces itself within 2 seconds of starting up, using default channel', () => {
+  it('announces itself when starting up, using default channel', () => {
     const announceSetup = require('../../scripts/startup_announce');
     announceSetup(robot);
 
-    return new Promise(resolve => {
-      setTimeout(() => {
-        expect(robot.messageRoom.calledWith('bots', { target: 'bots', text: sinon.match.string })).to.be.true;
-        resolve();
-      }, 2100);
-    });
-  }).timeout(2500);
+    expect(robot.messageRoom.calledWith('bots', { target: 'bots', text: sinon.match.string })).to.be.true;
+  });
 
   it('uses the channel value from the environment, if provided', () => {
     process.env.HUBOT_STATUS_CHANNEL = 'status-channel'
     const announceSetup = require('../../scripts/startup_announce');
     announceSetup(robot);
 
-    return new Promise(resolve => {
-      setTimeout(() => {
-        expect(robot.messageRoom.calledWith('status-channel', { target: 'status-channel', text: sinon.match.string })).to.be.true;
-        resolve();
-      }, 2100);
-    });
-  }).timeout(2500);
+    expect(robot.messageRoom.calledWith('status-channel', { target: 'status-channel', text: sinon.match.string })).to.be.true;
+  });
 });


### PR DESCRIPTION
When the bot starts, post a message to the channel described in the `HUBOT_STATUS_CHANNEL` environment variable (or `#bots` by default).  That way if the bot needs a reboot, folks in the channel will know it has happened.

Hopefully the bot doesn't just restart all the time and we end up flooded with messages, but that'd be useful information to know, anyway.  😬 