### PR TITLE
Fixup .cfignore

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,9 @@
-.gitignore
+.DS_Store*
+dump.rdb
+slack.yml
+.circleci
+.hubot_history
+.env
+.vscode
+bin
+test


### PR DESCRIPTION
Unlinks `.cifignore` from `.gitignore`.  This way we push `node_modules` into cloud.gov when we deploy.  Then the npm dependency versions deployed to cloud.gov are the same as the ones that were tested on CircleCI.  (Closes the loop on the `npm ci` change in #140)