### PR TITLE
Add dependency vulnerability testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,5 +15,10 @@ jobs:
           command: sudo npm i -g npm@^6.2
       - run: npm ci
       - run: npm test
+      - run:
+          name: dependency vulnerability scan
+          command: |
+            npx snyk auth $SNYK_TOKEN
+            npx snyk test
       - deploy:
           command: ./.circleci/deploy.sh

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -14,6 +14,8 @@ then
   # Log into CF and push
   cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
   cf push -f manifest.yml
+
+  npx snyk monitor --org=18f-bot-charlie
 else
   echo "Not on the master branch.  Not deploying."
 fi


### PR DESCRIPTION
Tests dependencies on each push, and after deploy, it logs the current set of dependencies for monitoring in the [18f-bot-charlie Snyk org](https://app.snyk.io/org/18f-bot-charlie).  The docs suggest that `snyk monitor` will cache off info about your installed dependencies rather than checking your manifest files, which should mitigate the problem with Snyk ignoring lockfiles.