### PR TITLE
Fix cfignore problem

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -5,5 +5,4 @@ slack.yml
 .hubot_history
 .env
 .vscode
-bin
-test
+./test


### PR DESCRIPTION
Wowee.  #141 un-ignored `node_modules` so that Charlie would be deployed with vendored dependencies.  Unfortunately, that broke the deployment in a weird way.  It kept complaining that `node_modules/aws_sdk/node_modules/uuid/bin/uuid` didn't exist.  That sent me on a wild goose chase, but eventually I found ***A*** goose:  our `.cfignore` file contained `bin` - and it was ignoring not just the `bin` directory in the project root, but also every `bin` directory under `node_modules`. 

I'm not sure if the scripts in the `bin` directory are actually useful anymore, but they look harmless so I removed it from `.cfignore`.  Then everything was happy.