### PR TITLE
Suppress specific vulnerability dependency warning

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.13.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-JUSTEXTEND-72674:
+    - sinon > nise > just-extend:
+        reason: not relevant
+        expires: '2019-01-13T14:07:53.024Z'
+patch: {}


### PR DESCRIPTION
The vulnerability warning from Snyk is not relevant.  It comes in via Sinon, so it would only manifest during testing, where no "real" data is accessible.  There's no available patched version yet, so just suppress the warning for now.