### PR TITLE
Switch to a Node.js version supported by cloud.gov

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "underscore": "^1.9.1"
   },
   "engines": {
-    "node": "^12.13.0"
+    "node": "^12.11.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
The Node.js buildpack on cloud.gov doesn't yet include the 12.13.x line, so downgrade slightly to the highest supported version.