### PR TITLE
Tweak OPM open/close status message

### DIFF
--- a/scripts/hugme.coffee
+++ b/scripts/hugme.coffee
@@ -22,39 +22,38 @@ appEnv = CFENV.getAppEnv()
 s3Creds = appEnv.getServiceCreds('charlie-bucket')
 if s3Creds == null
   console.log("Unable to find service creds for 'charlie-bucket'.")
-  return
+else
+  console.log("Found service creds for 'charlie-bucket'.")
 
-console.log("Found service creds for 'charlie-bucket'.")
+  creds = new AWS.Credentials(s3Creds.access_key_id, s3Creds.secret_access_key)
+  BUCKET = s3Creds.bucket
+  REGION = s3Creds.region
+  s3 = new AWS.S3({ region: REGION, credentials: creds })
 
-creds = new AWS.Credentials(s3Creds.access_key_id, s3Creds.secret_access_key)
-BUCKET = s3Creds.bucket
-REGION = s3Creds.region
-s3 = new AWS.S3({ region: REGION, credentials: creds })
+  hugUrl = (s3Object) ->
+    filename = s3Object.Key
+    rand = _u.random(10000)
+    return "https://s3-#{REGION}.amazonaws.com/#{BUCKET}/#{filename}?rnd=#{rand}"
 
-hugUrl = (s3Object) ->
-  filename = s3Object.Key
-  rand = _u.random(10000)
-  return "https://s3-#{REGION}.amazonaws.com/#{BUCKET}/#{filename}?rnd=#{rand}"
+  hugBomb = (count, msg) ->
+    s3.listObjects { Bucket: BUCKET }, (err, data) ->
+      if err
+        msg.reply("Error retrieving images: #{err}")
+      else
+        # send unique URLs
+        s3Objects = _u.sample(data.Contents, count)
+        for s3Object in s3Objects
+          url = hugUrl(s3Object)
+          msg.send(url)
+        msg.send("_If you would like to be added, send a picture in #bots._")
 
-hugBomb = (count, msg) ->
-  s3.listObjects { Bucket: BUCKET }, (err, data) ->
-    if err
-      msg.reply("Error retrieving images: #{err}")
-    else
-      # send unique URLs
-      s3Objects = _u.sample(data.Contents, count)
-      for s3Object in s3Objects
-        url = hugUrl(s3Object)
-        msg.send(url)
-      msg.send("_If you would like to be added, send a picture in #bots._")
+  module.exports = (robot) ->
+    if s3Creds == null
+      return
 
-module.exports = (robot) ->
-  if s3Creds == null
-    return
+    robot.respond /hug me/i, (msg) ->
+      hugBomb(1, msg)
 
-  robot.respond /hug me/i, (msg) ->
-    hugBomb(1, msg)
-
-  robot.respond /hug bomb( (\d+))?/i, (msg) ->
-    count = msg.match[2] || 3
-    hugBomb(count, msg)
+    robot.respond /hug bomb( (\d+))?/i, (msg) ->
+      count = msg.match[2] || 3
+      hugBomb(count, msg)

--- a/scripts/hugme.coffee
+++ b/scripts/hugme.coffee
@@ -22,6 +22,7 @@ appEnv = CFENV.getAppEnv()
 s3Creds = appEnv.getServiceCreds('charlie-bucket')
 if s3Creds == null
   console.log("Unable to find service creds for 'charlie-bucket'.")
+  return
 
 console.log("Found service creds for 'charlie-bucket'.")
 

--- a/scripts/opm_status.coffee
+++ b/scripts/opm_status.coffee
@@ -24,5 +24,8 @@ module.exports = (robot) ->
         msg.send "Well, what does Capital Weather Gang say?"
       else
         status = JSON.parse(body)
-        msg.send "#{icons[status.Icon]} #{status.Icon} for #{status.AppliesTo}. #{status.StatusSummary}. Read More: \n #{status.Url}"
+        msg.send
+          text: "#{icons[status.Icon]} #{status.Icon} for #{status.AppliesTo}. #{status.StatusSummary}. (<#{status.Url}|Read more>)"
+          unfurl_links: false
+          unfurl_media: false
       return


### PR DESCRIPTION
- Tweaks the OPM open/close status message to put the status URL into a link with text, and disables unfurling the link to reduce clutter:

  ![screenshot showing new bot behavior](https://user-images.githubusercontent.com/1775733/68514649-ee29c280-0243-11ea-90b7-606eea958c2b.png)

- Fixes a bug in the `hugme` script where it would continue to try to load even after discovering that S3 credentials were not set