### PR TITLE
Update OPM status message text.

### DIFF
--- a/scripts/opm_status.coffee
+++ b/scripts/opm_status.coffee
@@ -25,7 +25,7 @@ module.exports = (robot) ->
       else
         status = JSON.parse(body)
         msg.send
-          text: "#{icons[status.Icon]} #{status.Icon} for #{status.AppliesTo}. #{status.StatusSummary}. (<#{status.Url}|Read more>)"
+          text: "#{icons[status.Icon]} #{status.StatusSummary} for #{status.AppliesTo}. (<#{status.Url}|Read more>)"
           unfurl_links: false
           unfurl_media: false
       return


### PR DESCRIPTION
Following up on a request from @ToniBonittoGSA:

> Can the Charlie/O P M status bot be updated? Someone triggered it yesterday (I think trying to check for today's status a day ahead) and it had this:
> > :greenlight: Open for December 10, 2019. Open. (Read more)

Looks like the message is using the icon text to determine `:greenlight:` as well as echoing it out immediately after as a status summary — and then using the API-provided status summary later in the message, leading to the duplicate. 

According to [their status types API](https://www.opm.gov/developer/documentation/status-types-api/) we should be able to use `StatusSummary` for the first occurrence and it’ll make a pretty okay sentence: 

> :greenlight: Open for December 10, 2019. (Read more)
> :yellowlight: Delayed Arrival for December 10, 2019. (Read more)
> :redlight: Immediate Departure for December 10, 2019. (Read more)

My first 🤖PR!

![tada](https://user-images.githubusercontent.com/14930/70636585-cb544a80-1c03-11ea-83cb-bd7ae1dc56f2.gif)
