### PR TITLE
Adds a weekend/holiday auto-response to the travel channel

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,5 +7,13 @@
     "node": true,
     "es6": true
   },
-  "plugins": ["coffeescript"]
+  "plugins": ["coffeescript"],
+  "overrides": [
+    {
+      "files": ["test/**/*.js"],
+      "env": {
+        "mocha": true
+      }
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@18f/us-federal-holidays": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@18f/us-federal-holidays/-/us-federal-holidays-1.1.1.tgz",
-      "integrity": "sha1-2UmeUUvLk3bPz6ykg10E4WqHgGo="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@18f/us-federal-holidays/-/us-federal-holidays-1.4.0.tgz",
+      "integrity": "sha512-PKv+70d/9Rk8OEjKt7r/vro+pCrgJd4iy5kz1h+a6e/NF8IejZR+pbq8xNVabgDJTZxH6tIrDqHLTt7Hs5ABFw=="
     },
     "@babel/code-frame": {
       "version": "7.5.5",
@@ -2456,9 +2456,9 @@
       }
     },
     "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moment-timezone": {
       "version": "0.5.27",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "validate-config": "slack-github-issues validate config/slack-github-issues.json"
   },
   "dependencies": {
+    "@18f/us-federal-holidays": "^1.4.0",
     "@slack/client": "^5.0.2",
     "aws-sdk": "^2.656.0",
     "cfenv": "^1.2.2",
@@ -26,6 +27,7 @@
     "hubot-xkcd": "0.0.5",
     "js-yaml": "^3.13.1",
     "json": "^9.0.4",
+    "moment": "^2.24.0",
     "request": "^2.88.2",
     "sinon": "^7.5.0",
     "twit": "^2.2.11",

--- a/scripts/travel-team.js
+++ b/scripts/travel-team.js
@@ -1,0 +1,79 @@
+const holidays = require('@18f/us-federal-holidays');
+const moment = require('moment');
+
+const closedDays = ['Saturday', 'Sunday'];
+
+const getChannelName = (() => {
+  let allRooms = null;
+  return async (robot, roomID) => {
+    if (allRooms === null) {
+      await new Promise((resolve, reject) => {
+        robot.adapter.client.web.conversations.list((err, res) => {
+          if (err) {
+            reject(err);
+          }
+          allRooms = res.channels.reduce(
+            (rooms, { id, name }) => ({
+              ...rooms,
+              [id]: name
+            }),
+            {}
+          );
+          resolve();
+        });
+      });
+    }
+
+    return allRooms[roomID];
+  };
+})();
+
+const travelIsClosed = () =>
+  holidays.isAHoliday() || closedDays.includes(moment().format('dddd'));
+
+const getNextWorkday = () => {
+  const m = moment().add(1, 'day');
+  while (
+    closedDays.includes(m.format('dddd')) ||
+    holidays.isAHoliday(m.toDate())
+  ) {
+    m.add(1, 'day');
+  }
+  return m.format('dddd');
+};
+
+const pastResponses = [];
+const getHasRespondedToUserRecently = userID => {
+  // First, remove all previous responses that were over three hours ago
+  const threeHoursAgo = Date.now() - 3 * 60 * 60 * 1000;
+  for (let i = 0; i < pastResponses.length; i += 1) {
+    if (pastResponses[i].time <= threeHoursAgo) {
+      pastResponses.splice(i, 1);
+      i -= 1;
+    }
+  }
+
+  // Now check if any of the remaining responses are for this user
+  return pastResponses.some(p => p.user === userID);
+};
+
+module.exports = robot => {
+  robot.hear(/.*/, async msg => {
+    const channel = await getChannelName(robot, msg.message.room);
+    const user = msg.message.user.id;
+
+    if (
+      channel === 'travel' &&
+      travelIsClosed() &&
+      !getHasRespondedToUserRecently(user)
+    ) {
+      pastResponses.push({ user, time: Date.now() });
+      msg.send({
+        as_user: false,
+        icon_emoji: ':tts:',
+        text: `Hi <@${user}>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel ${getNextWorkday()} morning and someone will respond promptly.`,
+        username: 'TTS Travel Team'
+      });
+    }
+  });
+};

--- a/scripts/travel-team.js
+++ b/scripts/travel-team.js
@@ -71,7 +71,7 @@ module.exports = robot => {
       msg.send({
         as_user: false,
         icon_emoji: ':tts:',
-        text: `Hi <@${user}>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel ${getNextWorkday()} morning and someone will respond promptly.`,
+        text: `Hi <@${user}>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For after-hours emergency travel authorizations, see <https://handbook.tts.gsa.gov/travel-guide-b-after-hours-emergency-travel-authorizations/|the Handbook>. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel ${getNextWorkday()} morning and someone will respond promptly.`,
         username: 'TTS Travel Team'
       });
     }

--- a/test/scripts/travel-team.js
+++ b/test/scripts/travel-team.js
@@ -1,0 +1,159 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+const travelTeam = require('../../scripts/travel-team');
+
+describe('Travel Team out-of-office message', () => {
+  const sandbox = sinon.createSandbox();
+
+  const robot = {
+    hear: sandbox.stub(),
+    adapter: {
+      client: {
+        web: {
+          conversations: {
+            list: sandbox.stub()
+          }
+        }
+      }
+    }
+  };
+
+  let handler = null;
+  beforeEach(() => {
+    travelTeam(robot);
+    handler = robot.hear.args[0][1];
+
+    robot.adapter.client.web.conversations.list.yields(false, {
+      channels: [
+        { id: 'c1', name: 'channel 1' },
+        { id: 'ch2', name: 'travel' },
+        { id: 'ch3', name: 'channel 3' }
+      ]
+    });
+  });
+
+  afterEach(() => {
+    sandbox.resetBehavior();
+    sandbox.resetHistory();
+  });
+
+  it('subscribes to :all_the_things:', () => {
+    travelTeam(robot);
+    expect(robot.hear.calledWith(/.*/, sinon.match.func)).to.equal(true);
+  });
+
+  describe('message handler', () => {
+    const message = {
+      message: {
+        room: 'ch2',
+        user: {
+          id: 'user'
+        }
+      },
+      send: sandbox.spy()
+    };
+
+    beforeEach(() => {
+      message.message.room = 'ch2';
+      message.message.user.id = 'user';
+    });
+
+    it('does nothing if the incoming message is not directed to the #travel channel', async () => {
+      message.message.room = 'ch1';
+      await handler(message);
+      expect(message.send.called).to.equal(false);
+    });
+
+    it('does nothing if the current time is during the work week', async () => {
+      // Tuesday, Jnuary 17, 1984: US Supreme Court rules that recording on VHS
+      // tapes for later playback does not violate federal copyright laws.
+      const clock = sinon.useFakeTimers(443188800000);
+      await handler(message);
+      expect(message.send.called).to.equal(false);
+      clock.restore();
+    });
+
+    it('sends a message if the current time is during a federal holiday', async () => {
+      // Thursday, July 4, 1996: Hotmail is born.
+      const clock = sinon.useFakeTimers(836481600000);
+      await handler(message);
+
+      expect(
+        message.send.calledWith({
+          as_user: false,
+          icon_emoji: sinon.match.string,
+          text:
+            'Hi <@user>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Friday morning and someone will respond promptly.',
+          username: 'TTS Travel Team'
+        })
+      ).to.equal(true);
+      clock.restore();
+    });
+
+    it('sends a message if the current time is during a weekend', async () => {
+      // Sunday, October 19, 2003: Mother Teresa is beatified by Pope John
+      // Paul II.
+      const clock = sinon.useFakeTimers(1066564800000);
+      message.message.user.id = 'other_user';
+      await handler(message);
+
+      expect(
+        message.send.calledWith({
+          as_user: false,
+          icon_emoji: sinon.match.string,
+          text:
+            'Hi <@other_user>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Monday morning and someone will respond promptly.',
+          username: 'TTS Travel Team'
+        })
+      ).to.equal(true);
+      clock.restore();
+    });
+
+    it('does not send a message to the same user for at least 3 hours', async () => {
+      // Sunday, September 7, 2014: Serena Williams wins her third consecutive
+      // US Open title.
+      const clock = sinon.useFakeTimers(1410091200000);
+      message.message.user.id = 'repeat_user';
+      await handler(message);
+
+      expect(
+        message.send.calledWith({
+          as_user: false,
+          icon_emoji: sinon.match.string,
+          text:
+            'Hi <@repeat_user>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Monday morning and someone will respond promptly.',
+          username: 'TTS Travel Team'
+        })
+      ).to.equal(true);
+
+      sandbox.resetHistory();
+
+      await handler(message);
+      expect(message.send.called).to.equal(false);
+
+      sandbox.resetHistory();
+
+      // Switch users, make sure it does send a message to the new user
+      message.message.user.id = 'first_timer';
+      await handler(message);
+      expect(message.send.called).to.equal(true);
+
+      sandbox.resetHistory();
+
+      // Switch back to the repeat user.
+      message.message.user.id = 'repeat_user';
+      await handler(message);
+      expect(message.send.called).to.equal(false);
+
+      sandbox.resetHistory();
+
+      // Now move forward 3 hours and see that we get a new message for the user
+      clock.tick(3 * 60 * 60 * 1000);
+      await handler(message);
+      expect(message.send.called).to.equal(true);
+
+      clock.restore();
+    });
+  });
+});

--- a/test/scripts/travel-team.js
+++ b/test/scripts/travel-team.js
@@ -84,7 +84,7 @@ describe('Travel Team out-of-office message', () => {
           as_user: false,
           icon_emoji: sinon.match.string,
           text:
-            'Hi <@user>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Friday morning and someone will respond promptly.',
+            'Hi <@user>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For after-hours emergency travel authorizations, see <https://handbook.tts.gsa.gov/travel-guide-b-after-hours-emergency-travel-authorizations/|the Handbook>. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Friday morning and someone will respond promptly.',
           username: 'TTS Travel Team'
         })
       ).to.equal(true);
@@ -103,7 +103,7 @@ describe('Travel Team out-of-office message', () => {
           as_user: false,
           icon_emoji: sinon.match.string,
           text:
-            'Hi <@other_user>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Monday morning and someone will respond promptly.',
+            'Hi <@other_user>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For after-hours emergency travel authorizations, see <https://handbook.tts.gsa.gov/travel-guide-b-after-hours-emergency-travel-authorizations/|the Handbook>. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Monday morning and someone will respond promptly.',
           username: 'TTS Travel Team'
         })
       ).to.equal(true);
@@ -122,7 +122,7 @@ describe('Travel Team out-of-office message', () => {
           as_user: false,
           icon_emoji: sinon.match.string,
           text:
-            'Hi <@repeat_user>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Monday morning and someone will respond promptly.',
+            'Hi <@repeat_user>. The TTS travel team is unavailable on weekends and holidays. If you need to change your flight for approved travel, contact AdTrav at (877) 472-6716. For after-hours emergency travel authorizations, see <https://handbook.tts.gsa.gov/travel-guide-b-after-hours-emergency-travel-authorizations/|the Handbook>. For other travel-related issues, such as an approval in Concur, please drop a new message in this channel Monday morning and someone will respond promptly.',
           username: 'TTS Travel Team'
         })
       ).to.equal(true);


### PR DESCRIPTION
If a user sends a message in the #travel channel during a weekend or on a holiday, Charlie will automatically respond to them. Charlie will only respond to a user once every 3 hours to (hopefully) prevent spamming. We can tweak this later if we need to.

Here's an example of what the message looks like:

![screenshot of the new travel team autoresponder](https://user-images.githubusercontent.com/1775733/79610456-32a46e80-80be-11ea-9875-7d42d11a9051.png)
