### PR TITLE
Add a truancy report to a management channel

### DIFF
--- a/scripts/angry-tock.js
+++ b/scripts/angry-tock.js
@@ -188,6 +188,43 @@ let shout = robot => {
     slackableTruants.forEach(({ slack_id: slackID }) => {
       robot.messageRoom(slackID, message);
     });
+
+    if (!calm) {
+      if (truants.length > 0) {
+        const nonSlackableTruants = truants.filter(
+          t => !slackableTruants.some(s => s.email === t.email)
+        );
+
+        const report = [];
+        slackableTruants.forEach(u =>
+          report.push([`• <@${u.slack_id}> (notified on Slack)`])
+        );
+        nonSlackableTruants.forEach(u =>
+          report.push([`• ${u.username} (not notified)`])
+        );
+
+        robot.messageRoom('tock', {
+          attachments: [
+            {
+              fallback: report.join('\n'),
+              color: '#FF0000',
+              text: report.join('\n')
+            }
+          ],
+          username: 'Angry Tock',
+          icon_emoji: ':angrytock:',
+          text: '*The following users are currently truant on Tock:*',
+          as_user: false
+        });
+      } else {
+        robot.messageRoom('tock', {
+          username: 'Happy Tock',
+          icon_emoji: ':happy-tock:',
+          text: 'No Tock truants!',
+          as_user: false
+        });
+      }
+    }
   };
 };
 

--- a/scripts/angry-tock.js
+++ b/scripts/angry-tock.js
@@ -203,7 +203,7 @@ let shout = robot => {
           report.push([`• ${u.username} (not notified)`])
         );
 
-        robot.messageRoom('tock', {
+        robot.messageRoom('18f-gmt', {
           attachments: [
             {
               fallback: report.join('\n'),
@@ -217,7 +217,7 @@ let shout = robot => {
           as_user: false
         });
       } else {
-        robot.messageRoom('tock', {
+        robot.messageRoom('18f-gmt', {
           username: 'Happy Tock',
           icon_emoji: ':happy-tock:',
           text: 'No Tock truants!',

--- a/scripts/angry-tock.js
+++ b/scripts/angry-tock.js
@@ -1,7 +1,6 @@
 const holidays = require('@18f/us-federal-holidays');
 const moment = require('moment-timezone');
 const scheduler = require('node-schedule');
-const { promisify } = require('util');
 
 const TOCK_API_URL = process.env.HUBOT_TOCK_API;
 const TOCK_TOKEN = process.env.HUBOT_TOCK_TOKEN;
@@ -52,10 +51,15 @@ const m = () => moment.tz(ANGRY_TOCK_TIMEZONE);
  * @param {Object} robot Hubot robot object
  * @returns {Promise<Array<Object>>} A list of Slack users.
  */
-const getSlackUsers = async robot => {
-  const response = await promisify(robot.adapter.client.web.users.list)();
-  return response.members;
-};
+const getSlackUsers = async robot =>
+  new Promise((resolve, reject) => {
+    robot.adapter.client.web.users.list((err, response) => {
+      if (err) {
+        return reject(err);
+      }
+      return resolve(response.members);
+    });
+  });
 
 const getFromTock = async (robot, url) =>
   new Promise((resolve, reject) => {

--- a/test/scripts/angry-tock.js
+++ b/test/scripts/angry-tock.js
@@ -401,7 +401,7 @@ describe('Angry Tock', () => {
       moment.duration({ hours: 4, minutes: 45 }).asMilliseconds()
     );
 
-    expect(robot.messageRoom.callCount).to.equal(2);
+    expect(robot.messageRoom.callCount).to.equal(3);
 
     expect(
       robot.messageRoom.calledWith('slack1', {
@@ -417,6 +417,24 @@ describe('Angry Tock', () => {
         username: 'Angry Tock',
         icon_emoji: ':angrytock:',
         text: '<https://tock.18f.gov|Tock your time>! You gotta!',
+        as_user: false
+      })
+    ).to.equal(true);
+
+    expect(
+      robot.messageRoom.calledWith('tock', {
+        attachments: [
+          {
+            fallback:
+              '• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)\n• employee4 (not notified)\n• employee5 (not notified)',
+            color: '#FF0000',
+            text:
+              '• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)\n• employee4 (not notified)\n• employee5 (not notified)'
+          }
+        ],
+        username: 'Angry Tock',
+        icon_emoji: ':angrytock:',
+        text: '*The following users are currently truant on Tock:*',
         as_user: false
       })
     ).to.equal(true);
@@ -451,26 +469,33 @@ describe('Angry Tock', () => {
     // Last time. Advance to the secound shouting. This finishes all the shouty
     // routes through the bot and we can be done.
     robot.messageRoom.resetHistory();
+
+    // But first, clear out the truants, so we can test the case where Angry
+    // Tock's rage is sated and Happy Tock returns.
+    robot.http
+      .withArgs(sinon.match('tock url/reporting_period_audit/'))
+      .returns({
+        header: sinon
+          .stub()
+          .withArgs('Authorization', 'Token tock token')
+          .returns({
+            get: sinon
+              .stub()
+              .returns(sinon.stub().yields(false, null, JSON.stringify([])))
+          })
+      });
+
     await clock.tickAsync(
       moment.duration({ hours: 4, minutes: 45 }).asMilliseconds()
     );
 
-    expect(robot.messageRoom.callCount).to.equal(2);
+    expect(robot.messageRoom.callCount).to.equal(1);
 
     expect(
-      robot.messageRoom.calledWith('slack1', {
-        username: 'Angry Tock',
-        icon_emoji: ':angrytock:',
-        text: '<https://tock.18f.gov|Tock your time>! You gotta!',
-        as_user: false
-      })
-    ).to.equal(true);
-
-    expect(
-      robot.messageRoom.calledWith('slack2', {
-        username: 'Angry Tock',
-        icon_emoji: ':angrytock:',
-        text: '<https://tock.18f.gov|Tock your time>! You gotta!',
+      robot.messageRoom.calledWith('tock', {
+        username: 'Happy Tock',
+        icon_emoji: ':happy-tock:',
+        text: 'No Tock truants!',
         as_user: false
       })
     ).to.equal(true);

--- a/test/scripts/angry-tock.js
+++ b/test/scripts/angry-tock.js
@@ -422,7 +422,7 @@ describe('Angry Tock', () => {
     ).to.equal(true);
 
     expect(
-      robot.messageRoom.calledWith('tock', {
+      robot.messageRoom.calledWith('18f-gmt', {
         attachments: [
           {
             fallback:
@@ -492,7 +492,7 @@ describe('Angry Tock', () => {
     expect(robot.messageRoom.callCount).to.equal(1);
 
     expect(
-      robot.messageRoom.calledWith('tock', {
+      robot.messageRoom.calledWith('18f-gmt', {
         username: 'Happy Tock',
         icon_emoji: ':happy-tock:',
         text: 'No Tock truants!',


### PR DESCRIPTION
When Angry Tock runs on Monday afternoons, send a list of truants to the #tock channel as well as DM'ing the truant users. The goal is to make it easy for timekeeping and reporting folks to know whose timesheets might need manual tweaking.

![screenshot showing the truant report in the #tock channel](https://user-images.githubusercontent.com/1775733/80229944-d211b600-8616-11ea-8aa4-a443f7f0f754.png)
