### PR TITLE
Fixes a bug where everyone who has not Tocked is reported in the GMT channel, not just current 18F staff

### DIFF
--- a/scripts/angry-tock.js
+++ b/scripts/angry-tock.js
@@ -130,9 +130,15 @@ const getTockTruants = async robot => {
 
   const reportingPeriodStart = now.format('YYYY-MM-DD');
 
-  return getFromTock(
+  const tockUsers = await getCurrent18FTockUsers(robot);
+
+  const allTruants = await getFromTock(
     robot,
     `${TOCK_API_URL}/reporting_period_audit/${reportingPeriodStart}.json`
+  );
+
+  return allTruants.filter(truant =>
+    tockUsers.some(tockUser => tockUser.tock_id === truant.id)
   );
 };
 

--- a/test/scripts/angry-tock.js
+++ b/test/scripts/angry-tock.js
@@ -421,8 +421,6 @@ describe('Angry Tock', () => {
       })
     ).to.equal(true);
 
-    console.log(robot.messageRoom.args[2]);
-
     expect(
       robot.messageRoom.calledWith('18f-gmt', {
         attachments: [

--- a/test/scripts/angry-tock.js
+++ b/test/scripts/angry-tock.js
@@ -421,15 +421,17 @@ describe('Angry Tock', () => {
       })
     ).to.equal(true);
 
+    console.log(robot.messageRoom.args[2]);
+
     expect(
       robot.messageRoom.calledWith('18f-gmt', {
         attachments: [
           {
             fallback:
-              '• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)\n• employee4 (not notified)\n• employee5 (not notified)',
+              '• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)',
             color: '#FF0000',
             text:
-              '• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)\n• employee4 (not notified)\n• employee5 (not notified)'
+              '• <@slack1> (notified on Slack)\n• <@slack2> (notified on Slack)'
           }
         ],
         username: 'Angry Tock',


### PR DESCRIPTION
Prior to this bug, Solutions, Login, cloud.gov, separated, etc. staff would be reported in the 18F GMT channel. This fixes that, so only current 18F employees should be reported.