### PR TITLE
fix manifest to point to correct redis

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -8,5 +8,5 @@ applications:
   health-check-type: process
   host: charlie
   services:
-    - charlie-redis
+    - charlie-redis32
     - charlie-bucket


### PR DESCRIPTION
The manifest was pointing at the old Redis service, which was deprecated like... a year and a half or more ago. We've been using the newer service, but the manifest still referenced the old one. When I took down the old Redis service last week, it broke the manifest. This PR fixes the manifest.