### PR TITLE
Configure Dependabot to only create PRs for security fixes

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -14,8 +14,6 @@ then
   # Log into CF and push
   cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
   cf push -f manifest.yml
-
-  npx snyk monitor --org=18f-bot-charlie
 else
   echo "Not on the master branch.  Not deploying."
 fi

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    allowed_updates:
+      - match:
+          update_type: "security"


### PR DESCRIPTION
Dependabot is rather noisy, especially with `aws-sdk` getting multiple version bumps per day. To tone down the noise, configure it to only open PRs for security-related updates, not every version bump.