### PR TITLE
Coffeescript runtime is required for Hubot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1127,6 +1127,11 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
+    "coffeescript": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
+      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA=="
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@slack/client": "^5.0.2",
     "aws-sdk": "^2.782.0",
     "cfenv": "^1.2.3",
+    "coffeescript": "^1.12.7",
     "csvtojson": "^2.0.10",
     "hubot": "^3.3.2",
     "hubot-ascii-art": "^1.1.3",


### PR DESCRIPTION
So we can't actually *completely* remove it yet.