### PR TITLE
Handle messages with multiple timezones already included

### DIFF
--- a/test/scripts/timezone.js
+++ b/test/scripts/timezone.js
@@ -141,6 +141,29 @@ describe("Handy Tau-bot timezone conversions", () => {
       expect(postEphemeralMessage.callCount).to.equal(4);
     });
 
+    it("if multiple timezones are specified, it only messages people in a different timezone", async() => {
+      message.message.rawMessage.text = "03:00 :eastern-time-zone: | 02:00 :central-time-zone:";
+      await handler(message);
+
+      expect(
+        postEphemeralMessage.calledWith({
+          ...baseResponse,
+          user: "user 1",
+          text: "That's 1:00 for you!",
+        })
+      ).to.equal(true);
+
+      expect(
+        postEphemeralMessage.calledWith({
+          ...baseResponse,
+          user: "user 4",
+          text: "That's 11:00 for you!",
+        })
+      ).to.equal(true)
+
+      expect(postEphemeralMessage.callCount).to.equal(2);
+    });
+
     it("if a timezone is not specified, it messages everyone except the original author", async () => {
       message.message.rawMessage.text = "03:00";
       await handler(message);


### PR DESCRIPTION
The use case for this is handling messages like:

`1pm :eastern-time-zone: | 12pm :central-time-zone: | 11am :mountain-time-zone: | 10am :pacific-time-zone:`

but the regex will end up matching any times in the message whether or not they refer to the same real time.

I _think_ that case is no worse than the current implementation where it will only act on the first time it finds, with the chance for more users to be accidentally filtered out than would have currently been filtered, but I could be wrong.