### PR TITLE
Add some error checking and handling to coffeemate to help prevent users getting stuck in the queue

### DIFF
--- a/src/utils/test.js
+++ b/src/utils/test.js
@@ -15,7 +15,12 @@ module.exports = {
       action,
       brain: new Map(),
       logger: {
+        debug: jest.fn(),
+        error: jest.fn(),
+        getLevel: jest.fn(),
         info: jest.fn(),
+        setLevel: jest.fn(),
+        setName: jest.fn(),
         warn: jest.fn(),
       },
       message,


### PR DESCRIPTION
- bails out immediately if the `coffee me` was triggered by Slackbot
- if a coffee pair is found, catches exceptions to ensure that the queue is properly reset regardless
- adds appropriate tests