### PR TITLE
Add a helper script for accessing Charlie's dev and production databases

### DIFF
--- a/cf.js
+++ b/cf.js
@@ -1,0 +1,47 @@
+// A little helper script to create an SSH tunnel into Charlie that will forward
+// local port 55433 to the database Charlie uses to store its brain. Can be a
+// useful tool for debugging things that Charlie stores, like the coffeemate
+// queue or opt-outs.
+//
+// 1. log into cloud.gov
+// 2. target an org and space where Charlie is running
+// 3. run "node cf.js" and wait
+// 4. connect to Charlie's database at localhost, port 55433; you can find the
+//    username and password are available with "cf env charlie"
+
+const { exec } = require("child_process");
+
+const getServiceCredentials = async () =>
+  new Promise((resolve, reject) => {
+    exec("cf env charlie", (err, stdout) => {
+      if (err) {
+        return reject(new Error(err));
+      }
+      const [, services] = stdout.match(/VCAP_SERVICES: ({[\s\S]+?})\n\n/s);
+      const credentials = JSON.parse(services.trim());
+
+      return resolve(credentials);
+    });
+  });
+
+const main = async () => {
+  const creds = await getServiceCredentials();
+  if (creds["aws-rds"]) {
+    const brainCreds = creds["aws-rds"].find(
+      ({ name }) => name === "charlie-brain"
+    );
+    if (brainCreds) {
+      exec(
+        `cf ssh -L 55433:${brainCreds.credentials.host}:${brainCreds.credentials.port} charlie`,
+        () => {
+          console.log("connection terminated");
+        }
+      );
+    } else {
+      console.log("Couldn't find Charlie brain credentials");
+    }
+  } else {
+    console.log("Couldn't find database credentials");
+  }
+};
+main();


### PR DESCRIPTION
Charlie doesn't store much in its brain (database), but sometimes it's helpful to be able to take a peek inside to debug. That's possible to do with `cf ssh` and setting up some SSH tunnels. This script does exactly that, but also reads configuration data from cloud.gov so the user doesn't have to figure out the database host and port in order to establish the tunnel.

1. log into cloud.gov
2. target an org and space where Charlie is running
3. run `node cf.js` and wait 2 or 3 seconds; there's no output when it works, it just... doesn't fail
4. connect to Charlie's database at localhost, port 55433; you can find the username and password with `cf env charlie`
