### PR TITLE
Remove an encouragement that isn't always encouraging

### DIFF
--- a/src/scripts/encourage-bot.js
+++ b/src/scripts/encourage-bot.js
@@ -24,7 +24,6 @@ const messages = [
   "You are not here by accident. You deserve to be here.",
   "You make this a better place than it otherwise would have been.",
   "Your perspectives are valuable and valued.",
-  "You're braver than you believe, and stronger than you seem, and smarter than you think.", // A. A. Milne
 ];
 
 const getChannelUsers = async (channel) => {


### PR DESCRIPTION
This particular response can imply self-doubt that not everyone feels. And for some statistical quirk, it seems to be firing almost exclusively for women, which is a whole other uncool problem. So let's just yoink it for now while we figure out the best way to proceed with this bot in general.