### PR TITLE
tau-bot: skip times the author marked as local

### DIFF
--- a/src/scripts/timezone.js
+++ b/src/scripts/timezone.js
@@ -31,7 +31,12 @@ const TIMEZONES = {
 };
 
 const matcher =
-  /(\d{1,2}:\d{2}\s?(am|pm)?)\s?(((ak|a|c|e|m|p)(s|d)?t)|:(eastern|central|mountain|pacific)-time-zone:)?/i;
+  /(\d{1,2}:\d{2}\s?(am|pm)?)\s?(local(?:\s+time)?|((ak|a|c|e|m|p)(s|d)?t)|:(eastern|central|mountain|pacific)-time-zone:)?/i;
+
+// "local time" means whatever the reader's clock says, not the author's, so
+// there's nothing to convert. Mark those matches so we drop them up front.
+const isLocalTimeMatch = (timezone) =>
+  typeof timezone === "string" && /^local/i.test(timezone);
 
 module.exports = (app) => {
   helpMessage.registerNonInteractive(
@@ -56,7 +61,9 @@ module.exports = (app) => {
     let m = null;
     let ampm = null;
 
-    const matches = [...text.matchAll(RegExp(matcher, "gi"))];
+    const matches = [...text.matchAll(RegExp(matcher, "gi"))].filter(
+      ([, , , timezone]) => !isLocalTimeMatch(timezone),
+    );
 
     // If there aren't any matches, that can be because this was crossposted.
     // We don't want to have the bot respond to those because the authorship of

--- a/src/scripts/timezone.test.js
+++ b/src/scripts/timezone.test.js
@@ -242,17 +242,18 @@ describe("Handy Tau-bot timezone conversions", () => {
       expect(slack.postEphemeralMessage).not.toHaveBeenCalled();
     });
 
-    it("does not respond when the author marks the time as local", async () => {
-      // "local time" / "local" mean "whatever the reader's clock says", so
-      // there's nothing to translate. Tracked at #533.
-      for (const text of [
-        "Is 10:51 local time too early for more pizza talk?",
-        "meeting at 9:00 local",
-      ]) {
-        message.event.text = text;
-        await handler(message);
-        expect(slack.postEphemeralMessage).not.toHaveBeenCalled();
-      }
+    it('does not respond when the time is followed by "local time"', async () => {
+      message.event.text = "Is 10:51 local time too early for more pizza talk?";
+      await handler(message);
+
+      expect(slack.postEphemeralMessage).not.toHaveBeenCalled();
+    });
+
+    it('does not respond when the time is followed by "local"', async () => {
+      message.event.text = "meeting at 9:00 local";
+      await handler(message);
+
+      expect(slack.postEphemeralMessage).not.toHaveBeenCalled();
     });
 
     it("correctly converts 24 hour time", async () => {

--- a/src/scripts/timezone.test.js
+++ b/src/scripts/timezone.test.js
@@ -78,7 +78,7 @@ describe("Handy Tau-bot timezone conversions", () => {
     timezone(app);
 
     expect(app.message).toHaveBeenCalledWith(
-      /(\d{1,2}:\d{2}\s?(am|pm)?)\s?(((ak|a|c|e|m|p)(s|d)?t)|:(eastern|central|mountain|pacific)-time-zone:)?/i,
+      /(\d{1,2}:\d{2}\s?(am|pm)?)\s?(local(?:\s+time)?|((ak|a|c|e|m|p)(s|d)?t)|:(eastern|central|mountain|pacific)-time-zone:)?/i,
       expect.any(Function),
     );
   });
@@ -240,6 +240,19 @@ describe("Handy Tau-bot timezone conversions", () => {
       await handler(message);
 
       expect(slack.postEphemeralMessage).not.toHaveBeenCalled();
+    });
+
+    it("does not respond when the author marks the time as local", async () => {
+      // "local time" / "local" mean "whatever the reader's clock says", so
+      // there's nothing to translate. Tracked at #533.
+      for (const text of [
+        "Is 10:51 local time too early for more pizza talk?",
+        "meeting at 9:00 local",
+      ]) {
+        message.event.text = text;
+        await handler(message);
+        expect(slack.postEphemeralMessage).not.toHaveBeenCalled();
+      }
     });
 
     it("correctly converts 24 hour time", async () => {


### PR DESCRIPTION
Per #533, when someone writes "10:51 local time" they mean "whatever the reader's clock says," not "10:51 in my timezone," so Tau-bot's translation is misleading there. Added `local` / `local time` to the matcher and filter those matches out before processing so Tau-bot stays quiet.

Closes #533.